### PR TITLE
C89 compliance.

### DIFF
--- a/src/base64.c
+++ b/src/base64.c
@@ -55,8 +55,8 @@ char *base64_encode(const unsigned char *value, size_t vlen)
     }
     if (vlen > 0)
     {
-        *out++ = basis_64[value[0] >> 2];
         unsigned char oval = (value[0] << 4) & 0x30;
+        *out++ = basis_64[value[0] >> 2];
         if (vlen > 1) oval |= value[1] >> 4;
         *out++ = basis_64[oval];
         *out++ = (vlen < 2) ? '=' : basis_64[(value[1] << 2) & 0x3C];
@@ -74,12 +74,11 @@ char *base64_encode(const unsigned char *value, size_t vlen)
 // (result)         :    new unsigned char[] - decoded result
 unsigned char *base64_decode(const char *value, size_t *rlen)
 {
-    *rlen = 0;
     int c1, c2, c3, c4;
-
     size_t vlen = strlen(value);
     unsigned char *result =(unsigned char *)malloc((vlen * 3) / 4 + 1);
     unsigned char *out = result;
+    *rlen = 0;
 
     while (1)
     {

--- a/src/kerberosgss.c
+++ b/src/kerberosgss.c
@@ -256,6 +256,7 @@ int authenticate_gss_client_step(gss_client_state* state, const char* challenge)
     // Try to get the user name if we have completed all GSS operations
     if (ret == AUTH_GSS_COMPLETE)
     {
+        gss_buffer_desc name_token;
         gss_name_t gssuser = GSS_C_NO_NAME;
         maj_stat = gss_inquire_context(&min_stat, state->context, &gssuser, NULL, NULL, NULL,  NULL, NULL, NULL);
         if (GSS_ERROR(maj_stat))
@@ -265,7 +266,6 @@ int authenticate_gss_client_step(gss_client_state* state, const char* challenge)
             goto end;
         }
         
-        gss_buffer_desc name_token;
         name_token.length = 0;
         maj_stat = gss_display_name(&min_stat, gssuser, &name_token, NULL);
         if (GSS_ERROR(maj_stat))
@@ -433,6 +433,7 @@ int authenticate_gss_server_init(const char *service, gss_server_state *state)
 {
     OM_uint32 maj_stat;
     OM_uint32 min_stat;
+    size_t service_len;
     gss_buffer_desc name_token = GSS_C_EMPTY_BUFFER;
     int ret = AUTH_GSS_COMPLETE;
     
@@ -446,7 +447,7 @@ int authenticate_gss_server_init(const char *service, gss_server_state *state)
     state->response = NULL;
     
     // Server name may be empty which means we aren't going to create our own creds
-    size_t service_len = strlen(service);
+    service_len = strlen(service);
     if (service_len != 0)
     {
         // Import server name first


### PR DESCRIPTION
On CentOS 6.4, `python3.4 setup.py build` gives:

```
gcc -pthread -Werror=declaration-after-statement -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/usr/local/include/python3.4m -c src/kerberosgss.c -o build/temp.linux-x86_64-3.4/src/kerberosgss.o
src/kerberosgss.c: In function ‘authenticate_gss_client_step’:
src/kerberosgss.c:268: error: ISO C90 forbids mixed declarations and code
src/kerberosgss.c: In function ‘authenticate_gss_server_init’:
src/kerberosgss.c:449: error: ISO C90 forbids mixed declarations and code
error: command 'gcc' failed with exit status 1
```

Fixing that yields similar errors in `base64.c`.

`gcc --version` is `gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-4)`.

The change I'm proposing makes the code C89 compliant, and therefore C90 compliant. It fixes the compile error and complies with PEP7, which states:

> Use ANSI/ISO standard C (the 1989 version of the standard). This means (amongst many other things) that all declarations must be at the top of a block.
