### PR TITLE
Fix check_krb5_version when krb5-config version minor realase number is post fixed with something

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def check_krb5_config(*options):
 def check_krb5_version():
     krb5_vers = check_krb5_config("--version")
     if len(krb5_vers) == 4:
-        if int(krb5_vers[3].split('.')[1]) >= 10:
+        if int(krb5_vers[3].split('.')[1].split('-')[0]) >= 10:
             return r'-DGSSAPI_EXT'
 
 extra_link_args = check_krb5_config("--libs", "gssapi")


### PR DESCRIPTION
On my OSX 10.10.3, krb5-config --version returns:
Kerberos 5 release 1.7-prerelease
This patch removes the '-prerelease' before converting the release minor digit to int.

