### PR TITLE
replace explicit client credentials to gss_init_sec_context

### DIFF
--- a/src/kerberosgss.c
+++ b/src/kerberosgss.c
@@ -231,7 +231,7 @@ int authenticate_gss_client_step(gss_client_state* state, const char* challenge)
     // Do GSSAPI step
     Py_BEGIN_ALLOW_THREADS
     maj_stat = gss_init_sec_context(&min_stat,
-                                    NULL, //state->client_creds,
+                                    state->client_creds,
                                     &state->context,
                                     state->server_name,
                                     GSS_C_NO_OID,


### PR DESCRIPTION
Fixes #20 - suspect this change was merged for something that should've been done with delegation (or something else). Breaking support for explicit principals seems like a bad idea, and nobody can explain why it was done (see https://github.com/02strich/pykerberos/commit/1de650c804b015f880310d988da2fb6caa2e362f#diff-0ccb81c660d0b86530be6305e525b26cR235)