### PR TITLE
Fix reference to undefined command_name variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def check_krb5_config(*options, **kwargs):
             raise subprocess.CalledProcessError(retcode, cmd, output=output)
         return output.split()
     except OSError as e:
-        if e.errno == 2 and command_name != "krb5-config.mit":
+        if e.errno == 2 and cmd != "krb5-config.mit":
             try:
                 return check_krb5_config(*options, command_name="krb5-config.mit")
             except OSError as e2:


### PR DESCRIPTION
In setup.py check_krb5_config checks for 'command_name' in kwargs and
sets cmd to that value or falls back to 'krb5-config'. If there is an
error when trying to run either of those commands it checks an undefined
command_name variable. It should be checking cmd instead.