### PR TITLE
Fix TypeError when krb5-config is not present

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def check_krb5_config(*options, **kwargs):
 
 def check_krb5_version():
     krb5_vers = check_krb5_config("--version")
-    if len(krb5_vers) == 4:
+    if krb5_vers and len(krb5_vers) == 4:
         if int(krb5_vers[3].split('.')[1].split('-')[0]) >= 10:
             return r'-DGSSAPI_EXT'
 


### PR DESCRIPTION
Here's what we see now with 1.1.12 in OpenStack CI

  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/tmp.ixSstIV8nN/pip-build-x_yID4/pykerberos/setup.py", line 55, in <module>
      krb5_ver = check_krb5_version()
    File "/tmp/tmp.ixSstIV8nN/pip-build-x_yID4/pykerberos/setup.py", line 48, in check_krb5_version
      if len(krb5_vers) == 4:
  TypeError: object of type 'NoneType' has no len()

http://logs.openstack.org/41/323141/5/check/gate-requirements-tox-py27-with-upper-constraints/04b5a1b/console.html