### PR TITLE
Added option for setting gss mech oid (allows to implement SPNEGO authentication)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ debian/*.substvars
 debian/files
 pykerberos.egg-info/
 /kerberos.so
+.idea

--- a/pysrc/kerberos.py
+++ b/pysrc/kerberos.py
@@ -101,7 +101,7 @@ GSS_C_ANON_FLAG       = 64
 GSS_C_PROT_READY_FLAG = 128
 GSS_C_TRANS_FLAG      = 256
 
-def authGSSClientInit(service, principal=None, gssflags=GSS_C_MUTUAL_FLAG|GSS_C_SEQUENCE_FLAG):
+def authGSSClientInit(service, principal=None, gssflags=GSS_C_MUTUAL_FLAG|GSS_C_SEQUENCE_FLAG, mech_oid=None):
     """
     Initializes a context for GSSAPI client-side authentication with the given service principal.
     authGSSClientClean must be called after this function returns an OK result to dispose of
@@ -114,6 +114,8 @@ def authGSSClientInit(service, principal=None, gssflags=GSS_C_MUTUAL_FLAG|GSS_C_
     @param gssflags: optional integer used to set GSS flags.
         (e.g.  GSS_C_DELEG_FLAG|GSS_C_MUTUAL_FLAG|GSS_C_SEQUENCE_FLAG will allow
         for forwarding credentials to the remote host)
+    @param mech_oid: Optional GSS mech OID. Defaults to None (GSS_C_NO_OID).
+        Other possible values are GSS_MECH_OID_KRB5, GSS_MECH_OID_SPNEGO.
     @return: a tuple of (result, context) where result is the result code (see above) and
         context is an opaque value that will need to be passed to subsequent functions.
     """

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ if krb5_ver:
 
 setup (
     name = "pykerberos",
-    version = "1.1.13",
+    version = "1.1.14",
     description = "High-level interface to Kerberos",
     long_description=long_description,
     license="ASL 2.0",

--- a/src/kerberos.c
+++ b/src/kerberos.c
@@ -136,9 +136,15 @@ static PyObject* authGSSClientInit(PyObject* self, PyObject* args, PyObject* key
         return NULL;
     }
 
-    if (pymech_oid != NULL && PyCapsule_CheckExact(pymech_oid)) {
-        const char * mech_oid_name = PyCapsule_GetName(pymech_oid);
-        mech_oid = PyCapsule_GetPointer(pymech_oid, mech_oid_name);
+    if (pymech_oid != NULL) {
+        if (!PyCheck(pymech_oid)) {
+            PyErr_SetString(PyExc_TypeError, "Invalid type for mech_oid");
+            return NULL;
+        }
+        mech_oid = PyGet(pymech_oid, gss_OID_desc);
+        if (mech_oid == NULL) {
+            return NULL;
+        }
     }
 
     state = (gss_client_state *) malloc(sizeof(gss_client_state));
@@ -610,8 +616,8 @@ void initkerberos(void)
     PyDict_SetItemString(d, "GSS_C_ANON_FLAG", PyInt_FromLong(GSS_C_ANON_FLAG));
     PyDict_SetItemString(d, "GSS_C_PROT_READY_FLAG", PyInt_FromLong(GSS_C_PROT_READY_FLAG));
     PyDict_SetItemString(d, "GSS_C_TRANS_FLAG", PyInt_FromLong(GSS_C_TRANS_FLAG));
-    PyDict_SetItemString(d, "GSS_MECH_OID_KRB5", PyCapsule_New(&krb5_mech_oid, "kerberos.GSS_MECH_OID_KRB5", NULL));
-    PyDict_SetItemString(d, "GSS_MECH_OID_SPNEGO", PyCapsule_New(&spnego_mech_oid, "kerberos.GSS_MECH_OID_SPNEGO", NULL));
+    PyDict_SetItemString(d, "GSS_MECH_OID_KRB5", PyNew(&krb5_mech_oid, NULL));
+    PyDict_SetItemString(d, "GSS_MECH_OID_SPNEGO", PyNew(&spnego_mech_oid, NULL));
 
 error:
     if (PyErr_Occurred())

--- a/src/kerberos.c
+++ b/src/kerberos.c
@@ -143,6 +143,7 @@ static PyObject* authGSSClientInit(PyObject* self, PyObject* args, PyObject* key
         }
         mech_oid = PyGet(pymech_oid, gss_OID_desc);
         if (mech_oid == NULL) {
+            PyErr_SetString(PyExc_TypeError, "Invalid value for mech_oid");
             return NULL;
         }
     }

--- a/src/kerberos.c
+++ b/src/kerberos.c
@@ -34,6 +34,12 @@
     #define PyClear(object) PyCObject_SetVoidPtr(object, NULL)
 #endif
 
+static char krb5_mech_oid_bytes [] = "\x2a\x86\x48\x86\xf7\x12\x01\x02\x02";
+gss_OID_desc krb5_mech_oid = { 9, &krb5_mech_oid_bytes };
+
+static char spnego_mech_oid_bytes[] = "\x2b\x06\x01\x05\x05\x02";
+gss_OID_desc spnego_mech_oid = { 6, &spnego_mech_oid_bytes };
+
 PyObject *KrbException_class;
 PyObject *BasicAuthException_class;
 PyObject *PwdChangeException_class;
@@ -120,18 +126,25 @@ static PyObject* authGSSClientInit(PyObject* self, PyObject* args, PyObject* key
     const char *principal = NULL;
     gss_client_state *state;
     PyObject *pystate;
-    static char *kwlist[] = {"service", "principal", "gssflags", NULL};
+    gss_OID mech_oid = GSS_C_NO_OID;
+    PyObject *pymech_oid = NULL;
+    static char *kwlist[] = {"service", "principal", "gssflags", "mech_oid", NULL};
     long int gss_flags = GSS_C_MUTUAL_FLAG | GSS_C_SEQUENCE_FLAG;
     int result = 0;
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "s|zl", kwlist, &service, &principal, &gss_flags)) {
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "s|zlO", kwlist, &service, &principal, &gss_flags, &pymech_oid)) {
         return NULL;
+    }
+
+    if (pymech_oid != NULL && PyCapsule_CheckExact(pymech_oid)) {
+        const char * mech_oid_name = PyCapsule_GetName(pymech_oid);
+        mech_oid = PyCapsule_GetPointer(pymech_oid, mech_oid_name);
     }
 
     state = (gss_client_state *) malloc(sizeof(gss_client_state));
     pystate = PyNew(state, &destruct_client);
 
-    result = authenticate_gss_client_init(service, principal, gss_flags, state);
+    result = authenticate_gss_client_init(service, principal, gss_flags, mech_oid, state);
     if (result == AUTH_GSS_ERROR) {
         return NULL;
     }
@@ -597,6 +610,8 @@ void initkerberos(void)
     PyDict_SetItemString(d, "GSS_C_ANON_FLAG", PyInt_FromLong(GSS_C_ANON_FLAG));
     PyDict_SetItemString(d, "GSS_C_PROT_READY_FLAG", PyInt_FromLong(GSS_C_PROT_READY_FLAG));
     PyDict_SetItemString(d, "GSS_C_TRANS_FLAG", PyInt_FromLong(GSS_C_TRANS_FLAG));
+    PyDict_SetItemString(d, "GSS_MECH_OID_KRB5", PyCapsule_New(&krb5_mech_oid, "kerberos.GSS_MECH_OID_KRB5", NULL));
+    PyDict_SetItemString(d, "GSS_MECH_OID_SPNEGO", PyCapsule_New(&spnego_mech_oid, "kerberos.GSS_MECH_OID_SPNEGO", NULL));
 
 error:
     if (PyErr_Occurred())

--- a/src/kerberosgss.c
+++ b/src/kerberosgss.c
@@ -106,7 +106,7 @@ end:
     return result;
 }
 
-int authenticate_gss_client_init(const char* service, const char* principal, long int gss_flags, gss_client_state* state)
+int authenticate_gss_client_init(const char* service, const char* principal, long int gss_flags, gss_OID mech_oid, gss_client_state* state)
 {
     OM_uint32 maj_stat;
     OM_uint32 min_stat;
@@ -116,6 +116,7 @@ int authenticate_gss_client_init(const char* service, const char* principal, lon
 
     gss_OID mech;
     state->server_name = GSS_C_NO_NAME;
+    state->mech_oid = mech_oid;
     state->context = GSS_C_NO_CONTEXT;
     state->gss_flags = gss_flags;
     state->client_creds = GSS_C_NO_CREDENTIAL;
@@ -234,7 +235,7 @@ int authenticate_gss_client_step(gss_client_state* state, const char* challenge)
                                     state->client_creds,
                                     &state->context,
                                     state->server_name,
-                                    GSS_C_NO_OID,
+                                    state->mech_oid,
                                     (OM_uint32)state->gss_flags,
                                     0,
                                     NULL, //GSS_C_NO_CHANNEL_BINDINGS,

--- a/src/kerberosgss.h
+++ b/src/kerberosgss.h
@@ -33,6 +33,7 @@
 typedef struct {
     gss_ctx_id_t     context;
     gss_name_t       server_name;
+    gss_OID          mech_oid;
     long int         gss_flags;
     gss_cred_id_t    client_creds;
     char*            username;
@@ -53,7 +54,7 @@ typedef struct {
 
 char* server_principal_details(const char* service, const char* hostname);
 
-int authenticate_gss_client_init(const char* service, const char* principal, long int gss_flags, gss_client_state* state);
+int authenticate_gss_client_init(const char* service, const char* principal, long int gss_flags, gss_OID mech_oid, gss_client_state* state);
 int authenticate_gss_client_clean(gss_client_state *state);
 int authenticate_gss_client_step(gss_client_state *state, const char *challenge);
 int authenticate_gss_client_unwrap(gss_client_state* state, const char* challenge);


### PR DESCRIPTION
@02strich - Hello, I have ported https://github.com/apple/ccs-pykerberos/issues/47. It adds option for setting gss mech oid. If you agree and merge in this change, I am going to use this feature to implement SPNEGO authentication in requests_kerberos and urllib_kerberos. Here are corresponding forks:
https://github.com/mongodb-labs/winkerberos/pull/15
https://github.com/veklov/requests-kerberos
https://github.com/veklov/urllib_kerberos