### PR TITLE
Added support for Channel Binding Tokens

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -65,6 +65,59 @@ Then run test.py with suitable command line arguments:
     -p : password for basic authenticate
     -s : service principal for GSSAPI authentication (defaults to 'http@host.example.com')
 
+================
+CHANNEL BINDINGS
+================
+
+You can use this library to authenticate with Channel Binding support. Channel
+Bindings are tags that identify the particular data channel being used with the
+authentication. You can use Channel bindings to offer more proof of a valid
+identity. Some services like Microsoft's Extended Protection can enforce
+Channel Binding support on authorisation and you can use this library to meet
+those requirements.
+
+More details on Channel Bindings as set through the GSSAPI can be found here
+<https://docs.oracle.com/cd/E19455-01/806-3814/overview-52/index.html>. Using
+TLS as a example this is how you would add Channel Binding support to your
+authentication mechanism. The following code snippet is based on RFC5929
+<https://tools.ietf.org/html/rfc5929> using the 'tls-server-endpoint-point'
+type.
+
+.. code-block:: python
+
+   import hashlib
+
+    def get_channel_bindings_application_data(socket):
+        # This is a highly simplified example, there are other use cases
+        # where you might need to use different hash types or get a socket
+        # object somehow.
+        server_certificate = socket.getpeercert(True)
+        certificate_hash = hashlib.sha256(server_certificate).hexdigest().upper()
+        certificate_digest = base64.b16decode(certificate_hash)
+        application_data = b'tls-server-end-point:%s' % certificate_digest
+
+        return application_data
+
+    def main():
+        # Code to setup a socket with the server
+        # A lot of code to setup the handshake and start the auth process
+        socket = getsocketsomehow()
+
+        # Connect to the host and start the auth process
+
+        # Build the channel bindings object
+        application_data = get_channel_bindings_application_data(socket)
+        channel_bindings = kerberos.channelBindings(application_data=application_data)
+
+        # More work to get responses from the server
+
+        result, context = kerberos.authGSSClientInit(kerb_spn, gssflags=gssflags, principal=principal)
+
+        # Pass through the channel_bindings object as created in the kerberos.channelBindings method
+        result = kerberos.authGSSClientStep(context, neg_resp_value, channel_bindings=channel_bindings)
+
+        # Repeat as necessary
+
 ===========
 Python APIs
 ===========

--- a/pysrc/kerberos.py
+++ b/pysrc/kerberos.py
@@ -130,13 +130,16 @@ def authGSSClientClean(context):
     @return: a result code (see above).
     """
 
-def authGSSClientStep(context, challenge):
+def authGSSClientStep(context, challenge, **kwargs):
     """
     Processes a single GSSAPI client-side step using the supplied server data.
 
     @param context: the context object returned from authGSSClientInit.
     @param challenge: a string containing the base64-encoded server data (which may be empty
         for the first step).
+    @param channel_bindings: Optional channel bindings to bind onto the auth request. This
+        struct can be built using the channelBindings function and it not specified, this process
+        will pass along GSS_C_NO_CHANNEL_BINDINGS as a default
     @return: a result code (see above).
     """
 
@@ -237,4 +240,53 @@ def authGSSServerTargetName(context):
 
     @param context: the context object returned from authGSSServerInit.
     @return: a string containing the target name.
+    """
+
+"""
+Address Types for Channel Bindings
+https://docs.oracle.com/cd/E19455-01/806-3814/6jcugr7dp/index.html#reference-9
+"""
+
+GSS_C_AF_UNSPEC    = 0
+GSS_C_AF_LOCAL     = 1
+GSS_C_AF_INET      = 2
+GSS_C_AF_IMPLINK   = 3
+GSS_C_AF_PUP       = 4
+GSS_C_AF_CHAOS     = 5
+GSS_C_AF_NS        = 6
+GSS_C_AF_NBS       = 7
+GSS_C_AF_ECMA      = 8
+GSS_C_AF_DATAKIT   = 9
+GSS_C_AF_CCITT     = 10
+GSS_C_AF_SNA       = 11
+GSS_C_AF_DECnet    = 12
+GSS_C_AF_DLI       = 13
+GSS_C_AF_LAT       = 14
+GSS_C_AF_HYLINK    = 15
+GSS_C_AF_APPLETALK = 16
+GSS_C_AF_BSC       = 17
+GSS_C_AF_DSS       = 18
+GSS_C_AF_OSI       = 19
+GSS_C_AF_X25       = 21
+GSS_C_AF_NULLADDR  = 255
+
+def channelBindings(**kwargs):
+    """
+    Builds a gss_channel_bindings_struct which can be used to pass onto authGSSClientStep to bind
+    onto the auth. Details on Channel Bindings can be found at https://tools.ietf.org/html/rfc5929.
+    More details on the struct can be found at https://docs.oracle.com/cd/E19455-01/806-3814/overview-52/index.html
+
+    @param initiator_addrtype: Optional integer used to set the
+        initiator_addrtype, defaults to GSS_C_AF_UNSPEC if not set
+    @param initiator_address: Optional byte string containing the
+        initiator_address
+    @param acceptor_addrtype: Optional integer used to set the
+        acceptor_addrtype, defaults to GSS_C_AF_UNSPEC if not set
+    @param acceptor_address: Optional byte string containing the
+        acceptor_address
+    @param application_data: Optional byte string containing the
+        application_data. An example would be 'tls-server-end-point:{cert-hash}'
+        where {cert-hash} is the byte string hash of the server's certificate
+    @return: The gss_channel_bindings_struct pointer, which is the channel
+        bindings structure that can be passed onto authGSSClientStep
     """

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ if krb5_ver:
 
 setup (
     name = "pykerberos",
-    version = "1.1.14",
+    version = "1.2.0",
     description = "High-level interface to Kerberos",
     long_description=long_description,
     license="ASL 2.0",

--- a/src/kerberos.c
+++ b/src/kerberos.c
@@ -196,9 +196,9 @@ static PyObject *channelBindings(PyObject *self, PyObject *args, PyObject* keywd
     char *initiator_address = NULL;
     char *acceptor_address = NULL;
     char *application_data = NULL;
-    int initiator_length = NULL;
-    int acceptor_length = NULL;
-    int application_length = NULL;
+    int initiator_length = 0;
+    int acceptor_length = 0;
+    int application_length = 0;
 
     PyObject *pychan_bindings = NULL;
     struct gss_channel_bindings_struct *input_chan_bindings;

--- a/src/kerberosgss.c
+++ b/src/kerberosgss.c
@@ -205,7 +205,7 @@ int authenticate_gss_client_clean(gss_client_state *state)
     return ret;
 }
 
-int authenticate_gss_client_step(gss_client_state* state, const char* challenge, struct gss_channel_bindings_struct* input_chan_bindings)
+int authenticate_gss_client_step(gss_client_state* state, const char* challenge, struct gss_channel_bindings_struct* channel_bindings)
 {
     OM_uint32 maj_stat;
     OM_uint32 min_stat;
@@ -238,7 +238,7 @@ int authenticate_gss_client_step(gss_client_state* state, const char* challenge,
                                     state->mech_oid,
                                     (OM_uint32)state->gss_flags,
                                     0,
-                                    input_chan_bindings,
+                                    channel_bindings,
                                     &input_token,
                                     NULL,
                                     &output_token,

--- a/src/kerberosgss.c
+++ b/src/kerberosgss.c
@@ -205,7 +205,7 @@ int authenticate_gss_client_clean(gss_client_state *state)
     return ret;
 }
 
-int authenticate_gss_client_step(gss_client_state* state, const char* challenge)
+int authenticate_gss_client_step(gss_client_state* state, const char* challenge, struct gss_channel_bindings_struct* input_chan_bindings)
 {
     OM_uint32 maj_stat;
     OM_uint32 min_stat;
@@ -238,7 +238,7 @@ int authenticate_gss_client_step(gss_client_state* state, const char* challenge)
                                     state->mech_oid,
                                     (OM_uint32)state->gss_flags,
                                     0,
-                                    NULL, //GSS_C_NO_CHANNEL_BINDINGS,
+                                    input_chan_bindings,
                                     &input_token,
                                     NULL,
                                     &output_token,

--- a/src/kerberosgss.h
+++ b/src/kerberosgss.h
@@ -56,7 +56,7 @@ char* server_principal_details(const char* service, const char* hostname);
 
 int authenticate_gss_client_init(const char* service, const char* principal, long int gss_flags, gss_OID mech_oid, gss_client_state* state);
 int authenticate_gss_client_clean(gss_client_state *state);
-int authenticate_gss_client_step(gss_client_state *state, const char *challenge, struct gss_channel_bindings_struct *input_chan_bindings);
+int authenticate_gss_client_step(gss_client_state *state, const char *challenge, struct gss_channel_bindings_struct *channel_bindings);
 int authenticate_gss_client_unwrap(gss_client_state* state, const char* challenge);
 int authenticate_gss_client_wrap(gss_client_state* state, const char* challenge, const char* user, int protect);
 #ifdef GSSAPI_EXT

--- a/src/kerberosgss.h
+++ b/src/kerberosgss.h
@@ -56,7 +56,7 @@ char* server_principal_details(const char* service, const char* hostname);
 
 int authenticate_gss_client_init(const char* service, const char* principal, long int gss_flags, gss_OID mech_oid, gss_client_state* state);
 int authenticate_gss_client_clean(gss_client_state *state);
-int authenticate_gss_client_step(gss_client_state *state, const char *challenge);
+int authenticate_gss_client_step(gss_client_state *state, const char *challenge, struct gss_channel_bindings_struct *input_chan_bindings);
 int authenticate_gss_client_unwrap(gss_client_state* state, const char* challenge);
 int authenticate_gss_client_wrap(gss_client_state* state, const char* challenge, const char* user, int protect);
 #ifdef GSSAPI_EXT


### PR DESCRIPTION
This PR is to add support for generating Kerberos tokens with Channel Binding tokens. This is used in some areas to try and stop MiM attacks by having the authentication bind a value from a higher layer. I've tested this manually through a custom branch on requests-kerberos with a WinRM endpoint where the CBT level is set to strict.

I am a novice at C so happy to take some pointers around the code and potential improvements to what I have done.