### PR TITLE
obviously, verify shouldn't be const

### DIFF
--- a/src/kerberos.c
+++ b/src/kerberos.c
@@ -50,7 +50,7 @@ static PyObject *checkPassword(PyObject *self, PyObject *args) {
     const char *pswd = NULL;
     const char *service = NULL;
     const char *default_realm = NULL;
-    const int verify = 1;
+    int verify = 1;
     int result = 0;
 
     if (!PyArg_ParseTuple(args, "ssss|b", &user, &pswd, &service, &default_realm, &verify)) {


### PR DESCRIPTION
I found this when compiled by clang.
gcc didn't respect the const qualifier, however.