### PR TITLE
Update travis CI Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install libkrb5-dev


### PR DESCRIPTION
In a recent build travis had issues bootstrapping 2.6 and 3.3, so removing them. At the same time we now have 3.7 and 3.8 out, so adding them.